### PR TITLE
feat(ship,teach,docs,legal): previews, teach logs, docs (EPICS/JOURNEYS/LEGAL), CI seed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, feat/** ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install package (editable) + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+      - name: Run tests
+        run: |
+          pytest --cov --maxfail=1
+

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -113,3 +113,23 @@ Why
 
 Notes
 - Phase 1 acceptance: cover U1–U5, S1–S7, S12, S19 via unit+e2e
+
+---
+
+Date: 2025-09-03 (Legal guardrails seed)
+
+What changed
+- Added docs/LEGAL_GUARDRAILS.md and docs/POLICY_TEMPLATE.yaml
+- README: product positioning and legal overview appendix
+- TAURI: Legal Center, policy/profile wiring, review queue panels
+- Ship report: Legal Summary card placeholder, orchestrator passes legal context
+- Seeded epics (#30–#32) and tasks (#33–#42) for legal, format studio, and review/audit
+
+Why
+- Position Scraper as a “Local Knowledge Harvester & Compliance Packager” with CE/TDD guardrails
+
+Next up
+- Implement policy loader + --policy flag (issue #33)
+- Gate engine stub for PII+quotes (issue #34)
+- License detection + attribution (issue #35)
+- Robots/ToS snapshot + enforcement (issue #36)

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -65,3 +65,34 @@ Future (deferred)
 Notes
 - All new behavior is documented in README with examples and ASCII flows
 - Keep imports idempotent; add --update-existing later only when there’s a reviewer workflow
+
+---
+
+Date: 2025-09-03 (Teach + Preview upgrade)
+
+What changed
+- Ship command: added --teach and --preview flags to scraper ship local
+- HTML report: added Previews cards (2 sample questions per category; first bullet for each new summary)
+- Teach logs: labeled decisions for learning
+  - [teach §E. Validate] Levenshtein > 0.85 → reject
+  - [teach §F. SimHash] Hamming < 8 → skip near-duplicate question
+  - [teach §B. Heuristics] Enhanced TF‑IDF cosine max < 0.85 → unique
+- Orchestrator: fixed signature and CLI wiring; pass teach/preview through to harvesters/importers
+- Import (research): supports --teach to print category decision scoring
+
+Why
+- Improve explainability while running (teaching-first)
+- Provide fast visual sampling before full review (previews)
+
+How to use
+  scraper ship local \
+    --qm /path/to/QuizMentor.ai/quizzes \
+    --research /path/to/AI-Research \
+    --report-dir ./reports \
+    --teach --preview --strict \
+    --max-content 200 --questions-per-content 5
+
+Follow-ups
+- Strict gates (fail-fast) toggles for manifest/schema/tag mismatches
+- SimHash dedupe report section listing skipped questions with distances
+- Inline README anchors in teach logs like [teach §F. SimHash]

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -96,3 +96,20 @@ Follow-ups
 - Strict gates (fail-fast) toggles for manifest/schema/tag mismatches
 - SimHash dedupe report section listing skipped questions with distances
 - Inline README anchors in teach logs like [teach §F. SimHash]
+
+---
+
+Date: 2025-09-03 (Journeys + CE/TDD docs update)
+
+What changed
+- Added docs/JOURNEYS.md with 20 user + 20 S2S journeys
+- Updated docs/EPICS.md with CE principles, TDD gates, and references to journeys
+- Linked JOURNEYS and SYSTEM_STATUS from README
+- Added docs/SYSTEM_STATUS.md status snapshot
+- Created GitHub labels and issues for epics and tasks
+
+Why
+- Move to AI-OS-CE style with clear acceptance scenarios and TDD gates
+
+Notes
+- Phase 1 acceptance: cover U1–U5, S1–S7, S12, S19 via unit+e2e

--- a/README.md
+++ b/README.md
@@ -802,5 +802,7 @@ Appendix P — Productization & Tauri UI (proposal)
 This project can stand alone as a desktop product: local-only harvesting, previews, and teaching-first logs.
 - See docs/TAURI.md for a proposed Tauri UI (Rust + WebView) in the style of AI-OS-PRO
 - See docs/EPICS.md for epics, phases, and acceptance criteria (Frontend, Learning Center, Gating, Reports)
+- See docs/JOURNEYS.md for 20 user journeys and 20 system-to-system journeys used as acceptance scenarios
+- See docs/SYSTEM_STATUS.md for an at-a-glance status snapshot
 
 End of appendices.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ At a glance (local-only flows)
 +-----------+     +------------+     +----------------------+     +-------------------+      +----------------------+
 | Sources   | --> | Harvesters | --> | SQLite (harvest.db)  | --> | Exporters (quiz)  |  or  | Importers (research) |
 +-----------+     +------------+     +----------------------+     +-------------------+      +----------------------+
-                                                                  | quizzes/*.json    |      | summaries/*.md       |
-                                                                  | harvest_index.json|      | index.md updated     |
-                                                                  +-------------------+      +----------------------+
+                                                                 | quizzes/*.json    |      | summaries/*.md       |
+                                                                 | harvest_index.json|      | index.md updated     |
+                                                                 +-------------------+      +----------------------+
 
 Docking bays (adapters)
 - QuizMentor docking: local file drop-in to QuizMentor/quizzes/ (staging). No DB required.
@@ -67,6 +67,14 @@ Commands (cheat sheet)
   scraper import quizmentor --from ./out --to /path/to/QuizMentor.ai/quizzes --mode copy
 - Import entries to AI-Research repo (markdown + index, local-only):
   scraper import research --db ./harvest_output/harvest.db --repo /path/to/AI-Research --edition PRO --min-quality 0.75
+
+- Ship (one-shot, teach + preview):
+  scraper ship local \
+    --qm /path/to/QuizMentor.ai/quizzes \
+    --research /path/to/AI-Research \
+    --report-dir ./reports \
+    --teach --preview --strict \
+    --max-content 200 --questions-per-content 5
 
 
 Core concepts & glossary (plain English)
@@ -759,5 +767,40 @@ Appendix N — Teach me like I’m new (clarifications)
 - Sentinel file: an optional “done” marker; not necessary when we validate manifest and schema.
 - SimHash: a fast fingerprint for text; if two fingerprints differ by only a few bits (Hamming distance), the texts are near-duplicates.
 - Idempotent: safe to run again; nothing breaks or duplicates.
+
+
+Appendix O — Teach & Preview mode quickstart
+
+Teach mode (verbose learning logs)
+- Use --teach on ship or harvest/import commands to see labeled decisions:
+  - [teach §E. Validate] Levenshtein ratio > 0.85 → reject near-duplicate wording
+  - [teach §F. SimHash] Hamming distance < 8 → skip near-duplicate question by fingerprint
+  - [teach §B. Heuristics] EnhancedHarvester TF‑IDF cosine max < 0.85 → unique
+- These labels map to sections in this README so you can jump between logs and docs.
+
+Preview mode (fast sampling)
+- Use --preview on ship to include previews in the HTML report:
+  - Quizzes: two sample questions per category
+  - Research: the first bullet of each new summary
+
+One-shot with teach+preview
+  scraper ship local \
+    --qm /path/to/QuizMentor.ai/quizzes \
+    --research /path/to/AI-Research \
+    --report-dir ./reports \
+    --teach --preview --strict \
+    --max-content 200 --questions-per-content 5
+
+Heuristics thresholds (cheat sheet)
+- Uniqueness (text): Levenshtein ratio < 0.85
+- Uniqueness (semantic, enhanced): TF‑IDF cosine max < 0.85
+- Near-duplicate fingerprint (SimHash): Hamming distance < 8 → skip
+
+
+Appendix P — Productization & Tauri UI (proposal)
+
+This project can stand alone as a desktop product: local-only harvesting, previews, and teaching-first logs.
+- See docs/TAURI.md for a proposed Tauri UI (Rust + WebView) in the style of AI-OS-PRO
+- See docs/EPICS.md for epics, phases, and acceptance criteria (Frontend, Learning Center, Gating, Reports)
 
 End of appendices.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Scraper
 
+Product: Local Knowledge Harvester & Compliance Packager
+- Tagline: Privacy‑first harvesting and packaging with legal guardrails, previews, and teaching‑first explainability.
+- Who it serves: content/learning teams, platform/QA, legal/compliance, PMs.
+- Differentiators: local‑only, deterministic heuristics, TDD‑gated pipelines, teach logs that map to docs, configurable exporters/importers, and a desktop UI (Tauri).
+
 A modular educational content harvester and question-generation engine (extracted from QuizMentor.ai) with built-in exporters and importers for two targets:
 - QuizMentor (quizzes JSON) — local-only by default
 - AI-Research (markdown summaries + index updates) — local-only by default
@@ -806,3 +811,9 @@ This project can stand alone as a desktop product: local-only harvesting, previe
 - See docs/SYSTEM_STATUS.md for an at-a-glance status snapshot
 
 End of appendices.
+
+
+Appendix Q — Legal guardrails & policy (overview)
+- See docs/LEGAL_GUARDRAILS.md for the design and gates
+- Use docs/POLICY_TEMPLATE.yaml to create a project policy.yaml
+- Ship Report shows a Legal Summary card (placeholder until gates are implemented)

--- a/docs/EPICS.md
+++ b/docs/EPICS.md
@@ -1,0 +1,100 @@
+# EPICS – Scraper Productization
+
+This document captures product epics and acceptance criteria for evolving Scraper into a polished, local‑first desktop product. All epics assume offline/localhost execution, deterministic heuristics, and privacy by default.
+
+
+Epic 1 — One‑shot Ship UX (MVP)
+- Goal: Non‑technical users can run harvest → export → validate → import → report in one place.
+- Must have
+  - Command: scraper ship local with explicit paths (QM quizzes dir, AI‑Research repo)
+  - HTML report with totals, per‑quiz breakdown, research list, warnings
+  - Previews: 2 sample questions per category; first bullet of each new summary
+  - Teach mode: labeled logs ([teach §E], §F, §B) across pipeline
+- Done when
+  - A single command produces artifacts in out/ and reports/ with no manual steps
+  - A new editor can understand “what shipped” from HTML and logs
+
+
+Epic 2 — Strict Gates (fail‑fast)
+- Goal: Catch bad artifacts early; produce actionable errors.
+- Must have
+  - --strict option propagates to validation gates in ship
+  - Gates: manifest checksums, minimal schema, sanity stats
+  - Exit non‑zero on violations (configurable)
+  - Gate summary in HTML report
+- Done when
+  - Intentionally corrupting a quiz file stops ship with clear reasons
+
+
+Epic 3 — Dedupe Report & Teaching Aids
+- Goal: Make uniqueness decisions auditable and tunable.
+- Must have
+  - SimHash dedupe section in report: total skipped near‑dupes + top samples {distance, question}
+  - Teach log anchors referencing README sections (e.g., [teach §F. SimHash])
+  - Configurable thresholds (Levenshtein ratio, TF‑IDF cosine, SimHash Hamming)
+- Done when
+  - A reviewer can justify why a question was skipped and tweak thresholds to change outcomes
+
+
+Epic 4 — Learning Center (Docs-in-App)
+- Goal: Provide a self‑contained learning space that mirrors README sections.
+- Must have
+  - Concepts: glossary, diagrams, algorithms, thresholds
+  - Search across docs
+  - Link from teach logs to sections (deep links)
+- Done when
+  - A new user can become productive without leaving the app
+
+
+Epic 5 — Tauri Frontend (Desktop)
+- Goal: Cross‑platform GUI with local privacy guarantees.
+- Must have
+  - Shells out to the scraper CLI for operations (harvest/export/ship)
+  - Streams stdout/stderr into a “Teaching Console” panel
+  - Renders HTML report in‑app (webview) and links to artifacts folder
+  - Basic settings for paths and thresholds
+- Nice to have
+  - Tail the SQLite DB stats live (read‑only)
+  - Dark/light mode; keyboard shortcuts
+- Done when
+  - A user can run ship from the GUI and view the report without a terminal
+
+
+Epic 6 — Packaging & Distribution
+- Goal: Frictionless install on macOS/Linux/Windows.
+- Must have
+  - Python runtime packaging guidance or embedded runtime
+  - Tauri app bundle + code‑signed macOS app (dev cert ok)
+  - Versioned changelog + release notes
+- Done when
+  - A “Download app” + “Open” flow runs a sample ship on a demo project
+
+
+Epic 7 — Extensibility & Integrations (post‑MVP)
+- Goal: Add new harvesters/exporters/importers without core rewrites.
+- Must have
+  - Clear adapter interfaces and templates
+  - Example integration (e.g., flat questions.json, mock fixtures)
+  - Optional LLM enhancer clearly separated and off by default
+- Done when
+  - A contributor can add a new exporter with a small, documented module
+
+
+Roadmap Phases
+- Phase 0 (now): Teach/Preview + HTML report previews + docs
+- Phase 1 (MVP): Strict gates, dedupe report, Learning Center docs
+- Phase 2 (GUI): Tauri frontend invoking CLI, report rendering, settings
+- Phase 3 (Polish): Packaging, app signing, sample project, tutorials
+- Phase 4 (Extend): New adapters, optional enhancers, community contributions
+
+
+Non‑Goals (for now)
+- Cloud services, telemetry, or remote DBs
+- Replacing deterministic heuristics with black‑box models
+- Editing AI‑Research or QuizMentor repos beyond the current idempotent writes
+
+
+Links
+- README (teach/preview quickstart): ../README.md
+- Tauri UI proposal: ./TAURI.md
+

--- a/docs/EPICS.md
+++ b/docs/EPICS.md
@@ -1,6 +1,27 @@
-# EPICS – Scraper Productization
+# EPICS – Scraper Productization (CE Style + TDD)
 
-This document captures product epics and acceptance criteria for evolving Scraper into a polished, local‑first desktop product. All epics assume offline/localhost execution, deterministic heuristics, and privacy by default.
+This document captures product epics and acceptance criteria for evolving Scraper into a polished, local‑first desktop product in the AI‑OS‑CE style: community‑friendly, local‑first, transparent heuristics, and TDD‑gated delivery.
+
+Principles (CE)
+- Local‑first and privacy‑by‑default; no secrets, no cloud dependencies
+- Deterministic heuristics and explainability (teach logs map to docs)
+- Documentation‑as‑product: onboarding lives in the repo and UI
+- TDD as a gate: every epic has acceptance tests (unit + e2e) enforced by CI
+- Simple, composable CLIs with idempotent importers/exporters
+
+Testing strategy and gates (TDD)
+- Unit tests
+  - Algorithms: SimHash/Hamming thresholds; Levenshtein filters; TF‑IDF uniqueness
+  - Validators: quiz minimal schema; manifest integrity; category mapping
+  - CLI: flag wiring (--teach, --preview, --strict), param validation
+- E2E tests (network‑free)
+  - Mock harvest inputs to produce deterministic quiz+research outputs
+  - Run `scraper ship local` over a temp sandbox
+  - Verify: manifest totals, quiz schema, research files created, HTML report shows previews and gate summary
+- CI gates (GitHub Actions)
+  - Run unit + e2e suites; coverage threshold (initial 70%)
+  - No external network calls; use mocks/fixtures
+  - PRs must pass CI to merge
 
 
 Epic 1 — One‑shot Ship UX (MVP)
@@ -13,6 +34,7 @@ Epic 1 — One‑shot Ship UX (MVP)
 - Done when
   - A single command produces artifacts in out/ and reports/ with no manual steps
   - A new editor can understand “what shipped” from HTML and logs
+  - Acceptance tests pass in CI: unit (CLI wiring), e2e (ship over sandbox with previews)
 
 
 Epic 2 — Strict Gates (fail‑fast)
@@ -24,6 +46,7 @@ Epic 2 — Strict Gates (fail‑fast)
   - Gate summary in HTML report
 - Done when
   - Intentionally corrupting a quiz file stops ship with clear reasons
+  - Acceptance tests pass in CI: unit (validators), e2e (ship fails with clear gate reasons)
 
 
 Epic 3 — Dedupe Report & Teaching Aids
@@ -34,6 +57,7 @@ Epic 3 — Dedupe Report & Teaching Aids
   - Configurable thresholds (Levenshtein ratio, TF‑IDF cosine, SimHash Hamming)
 - Done when
   - A reviewer can justify why a question was skipped and tweak thresholds to change outcomes
+  - Acceptance tests pass in CI: unit (SimHash/ratio thresholds), e2e (report includes dedupe section with samples)
 
 
 Epic 4 — Learning Center (Docs-in-App)
@@ -44,6 +68,7 @@ Epic 4 — Learning Center (Docs-in-App)
   - Link from teach logs to sections (deep links)
 - Done when
   - A new user can become productive without leaving the app
+  - Acceptance tests pass in CI: unit (doc anchors map), e2e (teach logs link to docs in report or UI)
 
 
 Epic 5 — Tauri Frontend (Desktop)
@@ -58,6 +83,7 @@ Epic 5 — Tauri Frontend (Desktop)
   - Dark/light mode; keyboard shortcuts
 - Done when
   - A user can run ship from the GUI and view the report without a terminal
+  - Acceptance tests pass (separate UI CI later); headless smoke can invoke CLI and capture logs
 
 
 Epic 6 — Packaging & Distribution
@@ -68,6 +94,7 @@ Epic 6 — Packaging & Distribution
   - Versioned changelog + release notes
 - Done when
   - A “Download app” + “Open” flow runs a sample ship on a demo project
+  - Release pipeline publishes artifacts after tests pass; checksums attached
 
 
 Epic 7 — Extensibility & Integrations (post‑MVP)
@@ -81,11 +108,22 @@ Epic 7 — Extensibility & Integrations (post‑MVP)
 
 
 Roadmap Phases
-- Phase 0 (now): Teach/Preview + HTML report previews + docs
-- Phase 1 (MVP): Strict gates, dedupe report, Learning Center docs
-- Phase 2 (GUI): Tauri frontend invoking CLI, report rendering, settings
-- Phase 3 (Polish): Packaging, app signing, sample project, tutorials
+- Phase 0 (now): Teach/Preview + HTML report previews + docs (unit tests seed)
+- Phase 1 (MVP): Strict gates, dedupe report, Learning Center docs (unit + e2e gates)
+- Phase 2 (GUI): Tauri frontend invoking CLI, report rendering, settings (separate UI repo CI)
+- Phase 3 (Polish): Packaging, app signing, sample project, tutorials (release CI)
 - Phase 4 (Extend): New adapters, optional enhancers, community contributions
+
+Issue taxonomy (labels)
+- epic, task, bug, chore, docs, CE, TDD
+- domains: ship, harvest, export, import, research, quizmentor, ui, tauri
+- testing: test:unit, test:e2e, strict-gates, teach, preview
+
+References
+- CI workflow: .github/workflows/ci.yml
+- Tests root: /tests
+- README (teach/preview quickstart): ../README.md
+- Tauri UI proposal: ./TAURI.md
 
 
 Non‑Goals (for now)

--- a/docs/EPICS.md
+++ b/docs/EPICS.md
@@ -122,6 +122,7 @@ Issue taxonomy (labels)
 References
 - CI workflow: .github/workflows/ci.yml
 - Tests root: /tests
+- Journeys: ./JOURNEYS.md (U1–U20, S1–S20)
 - README (teach/preview quickstart): ../README.md
 - Tauri UI proposal: ./TAURI.md
 

--- a/docs/JOURNEYS.md
+++ b/docs/JOURNEYS.md
@@ -1,0 +1,181 @@
+# Journeys – User and System-to-System (CE Style)
+
+This document describes 20 user journeys (U1–U20) and 20 system-to-system journeys (S1–S20) for Scraper CE. Each journey lists goals, preconditions, steps, gates, success/failure signals, and artifacts.
+
+
+User Journeys (U1–U20)
+
+U1. Quick Ship (Local)
+- Role: Quiz Engineer
+- Goal: Produce fresh quizzes and research summaries locally
+- Preconditions: Python installed; QM quizzes dir and AI-Research repo paths
+- Steps:
+  1) scraper ship local --qm <path> --research <path> --report-dir ./reports --teach --preview --strict
+- Gates: manifest OK; quiz schema OK; sanity stats acceptable
+- Success: quizzes copied/linked; summaries created; report with previews
+- Failure: strict gates fail with clear reasons
+- Artifacts: out/quizzes/*.json, reports/ship-report.html
+
+U2. Research Import (Dry Run)
+- Role: Research Editor
+- Goal: Validate summaries and categories without writing
+- Steps: scraper import research --db <db> --repo <repo> --dry-run --teach --limit 10
+- Gates: category mapping explainable; quality >= min
+- Success: printed plan with categories and reasons
+- Failure: unknown tags escalate under --strict
+
+U3. Strict Gate Failure → Fix → Pass
+- Role: Engineer
+- Steps:
+  1) Run ship --strict
+  2) Intentionally corrupt a quiz file, rerun -> fail
+  3) Fix file, rerun -> pass
+- Gates: strict-gates block with actionable errors
+
+U4. Dedupe Review (SimHash)
+- Role: MLE/Editor
+- Steps: Run ship; open report; inspect dedupe section (skipped near-dupes + distances)
+- Success: Understand and justify skips
+
+U5. Teach-Driven Learning
+- Role: New User
+- Steps: Run ship --teach; follow [teach §X] links to README anchors
+- Success: Concepts learned without leaving repo
+
+U6. Category Subset Export
+- Role: Quiz Engineer
+- Steps: Export, then import only selected categories to QM (filter at importer)
+- Success: Only targeted categories docked
+
+U7. QA: Schema Spot Check
+- Role: QA
+- Steps: Validate quiz directory; sample open quiz_*.json
+- Gates: minimal schema, question count
+
+U8. Threshold Tuning Session
+- Role: MLE
+- Steps: Adjust thresholds; run e2e fixtures; compare dedupe and uniqueness
+- Success: Fewer duplicates, acceptable uniqueness
+
+U9. PM Report Review
+- Role: PM
+- Steps: Open reports/ship-report.html; review totals, warnings, previews
+
+U10. First-Time Setup
+- Role: New User
+- Steps: pip install -e .; run help; run a minimal ship to sample outputs
+
+U11. Tag Normalization Review
+- Role: Research Editor
+- Steps: Check tag→category mapping; add overrides JSON; re-run import
+
+U12. CSV Report for Analysis
+- Role: Data Analyst
+- Steps: Use generate_csv_report; load into spreadsheet for pivot tables
+
+U13. Scheduled Local Ship (Manual)
+- Role: DevOps
+- Steps: Write a cron job/launchd to run ship daily into timestamped out/
+
+U14. Source Rate-Limit Audit
+- Role: Security/Infra
+- Steps: Review harvester sleeps and headers; run small batch; confirm no spikes
+
+U15. Curation Loop (Idempotency)
+- Role: Editor
+- Steps: Delete a specific slug.md; re-run import to regenerate
+
+U16. Mock Fixtures for App Dev
+- Role: App Dev
+- Steps: Export flat questions.json (optional feature) for local app mocks
+
+U17. Regression Across Releases
+- Role: Release Eng
+- Steps: Run e2e suite before tagging; compare artifacts/manifest to baseline
+
+U18. GUI Trial (Tauri)
+- Role: Any
+- Steps: Use GUI to run ship; view Teaching Console; open report in-app
+
+U19. Learning Center Search
+- Role: New User
+- Steps: Use docs index/search to find topics quickly
+
+U20. Troubleshoot Unknown Tags
+- Role: Editor
+- Steps: Run import; see tag warnings; add to mapping or whitelist; re-run
+
+
+System-to-System Journeys (S1–S20)
+
+S1. Scraper → Exporter → QuizMentor Importer
+- Flow: SQLite (generated_questions) → quizzes/*.json → copy/link into QM/quizzes
+- Gates: schema validation; manifest
+
+S2. Scraper → AI-Research Importer
+- Flow: harvested_content → summaries/*.md + index.md append (idempotent)
+- Gates: min_quality; tag mapping; repo structure check
+
+S3. Export → Manifest
+- Flow: Write manifest.json with sha256, size, question counts
+- Gates: sha256 recomputed matches on validate
+
+S4. Validate → Gate Summary
+- Flow: Validation results summarized into HTML Report card
+
+S5. Harvest → Dedupe (SimHash)
+- Flow: Compute 64-bit SimHash; skip near-duplicates by Hamming threshold
+- Output: dedupe_skipped count + sample list for report
+
+S6. Teach Logs → Docs Anchors
+- Flow: Emit [teach §X] markers; map to README anchors in report
+
+S7. Orchestrator → HTML Report
+- Flow: Collect totals, warnings, previews; render static report
+
+S8. GUI (Tauri) → CLI
+- Flow: Tauri spawns `scraper ship local` and streams stdout/stderr
+
+S9. CLI → SQLite
+- Flow: Insert harvested_content and generated_questions; query for export/import
+
+S10. SQLite → CSV
+- Flow: generate_csv_report writes flattened questions for analysis
+
+S11. EnhancedHarvester → TF-IDF Similarity
+- Flow: Vectorize existing questions; enforce max cosine threshold
+
+S12. SimHash → Skipped Samples List
+- Flow: Record skipped near-dupes with {distance, question} (truncated) for report
+
+S13. Mapping File (JSON) → Category Decision
+- Flow: Merge user mapping with heuristics to decide categories
+
+S14. GitHub Actions → pytest → Coverage
+- Flow: CI runs tests, enforces >= 70% coverage, blocks merge on fail
+
+S15. Tag → Release (Packaging)
+- Flow: On tag, build artifacts, upload with checksums, draft release (future)
+
+S16. Research Importer → Idempotency Guard
+- Flow: Skip existing slug.md and existing index row
+
+S17. QM Importer → Mode (copy|link)
+- Flow: Choose symlink or copy; fallback to copy on failure
+
+S18. Repo Validator → Research Repo Check
+- Flow: Verify directories and template presence before writing
+
+S19. Strict Mode → Exit Code
+- Flow: Gate failures produce non-zero exit; CI fails accordingly
+
+S20. Previews Assembler → Report
+- Flow: Sample 1–2 quiz questions and first bullet per summary into report
+
+
+Acceptance Mapping
+- U1–U20 and S1–S20 must be covered by a combination of unit and e2e tests.
+- Minimal coverage per phase (see EPICS Roadmap):
+  - Phase 1: U1–U5, S1–S7, S12, S19
+  - Phase 2: U18–U19, S8; add smoke for GUI
+

--- a/docs/LEGAL_GUARDRAILS.md
+++ b/docs/LEGAL_GUARDRAILS.md
@@ -1,0 +1,43 @@
+# Legal Guardrails – Design (CE Style)
+
+Purpose
+- Provide privacy‑first, compliant harvesting and packaging with explainable decisions, fully local and testable.
+
+Scope (gates and policies)
+- Source policy and robots/ToS compliance
+  - Allow/deny lists per domain, path, topic; robots.txt honoring; rate limiting; contact email in UA
+  - ToS/licensing snapshot recorded per source (URL + hash + timestamp)
+- Licensing and attribution
+  - License detection: repo LICENSE/SPDX; web footer/meta; unknown when not determinable
+  - Per‑artifact license + attribution fields required
+  - Compatibility matrix (intended use: quiz vs research)
+  - Strict mode: block unknown/incompatible licenses; Normal: warn and queue for review
+- Content hygiene and PII
+  - PII/secret detectors (regex + entropy) on inputs/outputs; redaction or block in strict
+  - Quote length and percent reproduced thresholds; bias toward summaries; max quote chars
+  - Unsafe patterns flagged (e.g., unsafe code snippets) with reason codes
+- Provenance and audit
+  - Chain‑of‑custody: source URL, timestamps, content hash, simhash/fingerprint, license state at capture
+  - Immutable audit log of gate outcomes and overrides (who/why/when)
+- Jurisdiction toggles
+  - GDPR/CCPA purge hooks; export of data subjects list if applicable
+- Report & risk
+  - HTML Legal Summary card: per‑gate status (robots, license, attribution, PII, quotes), counts, reason codes, docs links
+  - Overall risk score: allow/warn/block
+
+Artifacts
+- policy.yaml: project policy (allow/deny, license matrix, PII rules, thresholds, strict behaviors)
+- GateResults: structured results with IDs, reason codes, remediation hints
+- Audit log: append‑only records of results and overrides
+
+CLI additions
+- --policy policy.yaml, --profile <name>, --compliance-only, --remediate=redact|exclude
+
+TDD
+- Unit: license detection (spdx/heuristics), attribution required, PII detectors, quote thresholds
+- E2E: strict blocks unknown license; redaction removes PII; quote reduction passes; robots honored for disallowed domains
+
+References
+- POLICY_TEMPLATE.yaml (this folder)
+- README (Product positioning and quickstart)
+

--- a/docs/POLICY_TEMPLATE.yaml
+++ b/docs/POLICY_TEMPLATE.yaml
@@ -1,0 +1,75 @@
+# Default policy template for Scraper CE
+# Copy to policy.yaml and customize per project.
+
+meta:
+  version: 1
+  project: "example"
+  contact_email: "owner@example.com"
+
+robots_tos:
+  honor_robots: true
+  rate_limit:
+    requests_per_minute: 30
+    burst: 10
+  tos_snapshot: true  # record ToS URL + hash + timestamp
+
+allowlists:
+  domains: ["docs.aws.amazon.com", "kubernetes.io", "developer.mozilla.org"]
+  paths: []
+  topics: []
+
+denylists:
+  domains: []
+  paths: ["/private", "/account"]
+  topics: []
+
+licenses:
+  compatibility_matrix:
+    quiz:
+      allowed: ["MIT", "Apache-2.0", "BSD-3-Clause", "CC-BY-4.0"]
+      warn: ["CC-BY-NC-4.0"]
+      block: ["Proprietary", "All Rights Reserved", "Unknown"]
+    research:
+      allowed: ["MIT", "Apache-2.0", "BSD-3-Clause", "CC-BY-4.0", "CC-BY-SA-4.0"]
+      warn: ["CC-BY-NC-4.0"]
+      block: ["Proprietary", "All Rights Reserved", "Unknown"]
+  require_attribution: true
+
+pii:
+  enable: true
+  detectors:
+    - name: email
+      type: regex
+      pattern: "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+    - name: phone
+      type: regex
+      pattern: "\b\+?[0-9][0-9\-\s]{6,}[0-9]\b"
+    - name: secret_key
+      type: entropy
+      min_length: 20
+      entropy_bits: 3.5
+  action:
+    normal: redact
+    strict: block
+
+quotes:
+  max_chars: 240
+  max_percent_reproduced: 0.15
+  bias_toward_summary: true
+
+unsafe_content:
+  flag_code_execution: true
+
+jurisdiction:
+  gdpr_purge: true
+  ccpa_purge: true
+
+strict_behaviors:
+  unknown_license: block
+  incompatible_license: block
+  robots_disallow: block
+
+remediation:
+  default: redact
+  alternatives: ["redact", "exclude", "flag"]
+

--- a/docs/SYSTEM_STATUS.md
+++ b/docs/SYSTEM_STATUS.md
@@ -1,0 +1,44 @@
+# System Status – Scraper CE
+
+Snapshot time: 2025-09-03T23:04:07Z
+
+Branches
+- main (default)
+- feat/preview-teach-docs-tauri (active): adds teach/preview wiring, HTML previews, docs updates
+
+CI
+- Workflow: .github/workflows/ci.yml – pytest with coverage
+- Coverage target (planned): >= 70% (see issue #25)
+
+Docs
+- README: onboarding + teach/preview quickstart
+- DEVLOG: updated with teach/preview and docs work
+- EPICS: CE + TDD principles, epics with acceptance criteria
+- JOURNEYS: 20 user + 20 S2S journeys
+- TAURI: UI proposal
+
+Open Epics
+- #1 Ship UX (MVP)
+- #2 Strict Gates (fail-fast)
+- #3 Dedupe Report & Teaching Aids
+- #4 Learning Center (Docs-in-App)
+- #5 Tauri Frontend (Desktop)
+- #6 Packaging & Distribution
+- #7 Extensibility & Integrations
+
+Recent Changes
+- Added --preview to ship, teach logs labeled, report previews
+- Updated README, DEVLOG, EPICS; added JOURNEYS and TAURI docs
+- Created CI workflow and initial unit test (SimHash)
+- Created labels and issues for epics/tasks
+
+Next Actions
+- Implement Gate Summary report card (#8)
+- Add e2e ship test harness with fixtures (#9)
+- Add strict gates unit + e2e tests (#11–#13)
+
+Links
+- Repo: https://github.com/MarcoPWx/Scraper
+- PR: https://github.com/MarcoPWx/Scraper/pull/new/feat/preview-teach-docs-tauri
+- Issues: https://github.com/MarcoPWx/Scraper/issues
+

--- a/docs/TAURI.md
+++ b/docs/TAURI.md
@@ -1,0 +1,80 @@
+# Tauri UI Proposal – Scraper Desktop
+
+This document outlines a local‑first desktop UI for Scraper using Tauri (Rust core + WebView). It mirrors the AI‑OS‑PRO style: a left navigation, top toolbar, and content panels with streaming logs and rich reports.
+
+
+Goals
+- Run the full pipeline locally with clear, teach‑first feedback
+- Zero secrets, zero cloud dependencies by default
+- Cross‑platform (macOS, Linux, Windows) with small binary size
+
+
+Information Architecture
+- Navigation
+  - Dashboard: quick actions, last run status, recent reports
+  - Harvest: configure and run Massive/Enhanced, view content counts
+  - Quizzes: browse exported quiz_* files by category; quick sample questions
+  - Research: list new/updated summaries; link to index.md
+  - Ship (One‑shot): orchestrate harvest → export → validate → import → report
+  - Reports: open reports/ship-report.html and history
+  - Settings: paths (output_dir, quizzes dir, research repo), thresholds, strict gates
+  - Learning Center: embedded docs mirroring README and EPICS (searchable)
+
+- Panels
+  - Teaching Console: real‑time stream of --teach logs with anchors to docs
+  - Artifacts Explorer: tree of out/ and reports/
+  - Preview Cards: inline sample questions and summary bullets
+
+
+Technical Design
+- Invocation model
+  - The UI calls the bundled scraper CLI as a subprocess (e.g., `scraper ship local ...`)
+  - Stream stdout/stderr via Tauri Command API to the Teaching Console
+  - Read artifacts (manifest.json, quizzes/*.json, reports/ship-report.html) from disk
+
+- IPC & Permissions
+  - Minimal IPC: only run whitelisted commands with validated parameters
+  - Never display or log secrets; no network access required
+
+- Rendering
+  - Use the OS webview to render the HTML report directly
+  - Lightweight UI components (Svelte/React) for lists, forms, and consoles
+
+- State & Config
+  - Store user settings (paths, thresholds) in the app config dir
+  - Remember last run parameters and report location for quick reopen
+
+- Packaging
+  - Tauri bundler for macOS app; sign with a developer cert
+  - Include a quickstart sample project (optional) for first‑run demo
+
+
+MVP Scope
+- Launch app; configure paths
+- Run `ship local` with `--teach --preview --strict`
+- Show streaming logs and a link to open the generated HTML report
+- Render basic previews (read from artifacts)
+
+
+Stretch Goals
+- Embedded report viewer (render HTML within the app)
+- Threshold sliders with live preview of how they would affect decisions (simulated)
+- Live stats from SQLite (read‑only), e.g., total questions by category
+- Keyboard shortcuts and dark mode
+
+
+Risks & Mitigations
+- Cross‑platform path differences → use Tauri APIs for path joins; validate paths at form level
+- Long‑running processes → stream logs, allow safe cancel, detect non‑zero exit codes and show actionable errors
+- Binary size creep → keep dependencies minimal; reuse system Python or document runtime requirements
+
+
+Open Questions
+- Should we embed Python or require a local Python? (lean: require local Python with clear onboarding)
+- Do we ship a sample dataset to demonstrate the UI without network access? (lean: yes, small sample)
+
+
+References
+- README: teach/preview quickstart
+- EPICS: high‑level goals and acceptance criteria
+

--- a/docs/TAURI.md
+++ b/docs/TAURI.md
@@ -7,6 +7,7 @@ Goals
 - Run the full pipeline locally with clear, teach‑first feedback
 - Zero secrets, zero cloud dependencies by default
 - Cross‑platform (macOS, Linux, Windows) with small binary size
+- Provide a Legal Center to configure policies, review flags, and maintain audit trails
 
 
 Information Architecture
@@ -17,13 +18,16 @@ Information Architecture
   - Research: list new/updated summaries; link to index.md
   - Ship (One‑shot): orchestrate harvest → export → validate → import → report
   - Reports: open reports/ship-report.html and history
-  - Settings: paths (output_dir, quizzes dir, research repo), thresholds, strict gates
+  - Legal Center: policy wizard, flagged items queue, audit trail
+  - Settings: paths (output_dir, quizzes dir, research repo), thresholds, strict gates, policy/profile
   - Learning Center: embedded docs mirroring README and EPICS (searchable)
 
 - Panels
   - Teaching Console: real‑time stream of --teach logs with anchors to docs
   - Artifacts Explorer: tree of out/ and reports/
   - Preview Cards: inline sample questions and summary bullets
+  - Legal Summary: table of legal gates and counts; click through to flagged items
+  - Review Queue: triage UI (Fix/Redact/Exclude) with reason codes
 
 
 Technical Design
@@ -31,6 +35,7 @@ Technical Design
   - The UI calls the bundled scraper CLI as a subprocess (e.g., `scraper ship local ...`)
   - Stream stdout/stderr via Tauri Command API to the Teaching Console
   - Read artifacts (manifest.json, quizzes/*.json, reports/ship-report.html) from disk
+  - Policy/Profile awareness: pass --policy and --profile to CLI; persist settings in app config
 
 - IPC & Permissions
   - Minimal IPC: only run whitelisted commands with validated parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,13 @@ dependencies = [
   "rich>=13.5.2"
 ]
 
+[project.optional-dependencies]
+test = [
+  "pytest>=7.4",
+  "pytest-cov>=4.1",
+  "requests-mock>=1.11.0"
+]
+
 [project.urls]
 Homepage = "https://github.com/MarcoPWx/Scraper"
 
@@ -43,4 +50,8 @@ scraper = "scraper.cli:main"
 
 [tool.hatch.build]
 packages = ["src/scraper"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
 

--- a/src/scraper/cli.py
+++ b/src/scraper/cli.py
@@ -11,6 +11,8 @@ Usage examples:
 """
 
 import argparse
+import json
+from rich.console import Console
 from pathlib import Path
 
 from .harvesters.massive import MassiveHarvester
@@ -115,6 +117,8 @@ def cmd_ship_local(args) -> int:
         mode=args.mode,
         strict=args.strict,
         limit=args.limit,
+        teach=args.teach,
+        preview=args.preview,
     )
     print(json.dumps({k: v for k, v in result.items() if k in ("db", "export", "report")}, indent=2))
     return 0
@@ -170,6 +174,7 @@ def build_parser() -> argparse.ArgumentParser:
     iar.add_argument("--mapping", help="Optional JSON tag→category mapping file", default=None)
     iar.add_argument("--dry-run", action="store_true")
     iar.add_argument("--limit", type=int, default=None)
+    iar.add_argument("--teach", action="store_true")
     iar.set_defaults(func=cmd_import_airesearch)
 
     # validate
@@ -209,6 +214,7 @@ def build_parser() -> argparse.ArgumentParser:
     local.add_argument("--strict", action="store_true")
     local.add_argument("--teach", action="store_true")
     local.add_argument("--limit", type=int, default=None)
+    local.add_argument("--preview", action="store_true")
     local.set_defaults(func=cmd_ship_local)
 
     return parser

--- a/src/scraper/harvesters/enhanced.py
+++ b/src/scraper/harvesters/enhanced.py
@@ -233,7 +233,7 @@ class EnhancedHarvester:
             similarities = cosine_similarity(new_vector, self.question_vectors)
             max_similarity = similarities.max()
             if self.teach:
-                console.print(f"[blue]TF‑IDF cosine max[/blue]={max_similarity:.2f} < {threshold:.2f} → {'unique' if max_similarity < threshold else 'not unique'}")
+                console.print(f"[blue][teach §B. Heuristics][/blue] TF‑IDF cosine max={max_similarity:.2f} < {threshold:.2f} → {'unique' if max_similarity < threshold else 'not unique'}")
             return max_similarity < threshold
         except Exception:
             for existing in self.existing_questions[-100:]:

--- a/src/scraper/html_report.py
+++ b/src/scraper/html_report.py
@@ -12,6 +12,8 @@ def write_ship_report(path: str, context: Dict[str, Any]) -> Path:
     totals = context.get("totals", {})
     quizzes = context.get("quizzes", [])
     research = context.get("research", [])
+    previews_quiz = context.get("previews_quiz", [])
+    previews_research = context.get("previews_research", [])
     warnings = context.get("warnings", [])
     params = context.get("params", {})
 
@@ -32,6 +34,12 @@ def write_ship_report(path: str, context: Dict[str, Any]) -> Path:
         for r in research
     )
     warn_list = "".join(f"<li>{esc(json.dumps(w))}</li>" for w in warnings)
+    preview_quiz_list = "".join(
+        f"<li><b>{esc(p.get('category',''))}</b>: {esc(p.get('q1',''))} | {esc(p.get('q2',''))}</li>" for p in previews_quiz
+    )
+    preview_research_list = "".join(
+        f"<li><b>{esc(p.get('slug',''))}</b>: {esc(p.get('first_bullet',''))}</li>" for p in previews_research
+    )
 
     html = f"""<!doctype html>
 <html>
@@ -82,6 +90,16 @@ code {{ background: #f7f7f7; padding: 1px 4px; border-radius: 4px; }}
 <div class=\"card\">
   <h2>Warnings</h2>
   <ul>{warn_list or '<li>None</li>'}</ul>
+</div>
+
+<div class=\"card\">
+  <h2>Previews (Quiz)</h2>
+  <ul>{preview_quiz_list or '<li>None</li>'}</ul>
+</div>
+
+<div class=\"card\">
+  <h2>Previews (Research)</h2>
+  <ul>{preview_research_list or '<li>None</li>'}</ul>
 </div>
 
 </body>

--- a/src/scraper/html_report.py
+++ b/src/scraper/html_report.py
@@ -16,6 +16,7 @@ def write_ship_report(path: str, context: Dict[str, Any]) -> Path:
     previews_research = context.get("previews_research", [])
     warnings = context.get("warnings", [])
     params = context.get("params", {})
+    legal = context.get("legal", {})
 
     def esc(s: str) -> str:
         return (
@@ -39,6 +40,9 @@ def write_ship_report(path: str, context: Dict[str, Any]) -> Path:
     )
     preview_research_list = "".join(
         f"<li><b>{esc(p.get('slug',''))}</b>: {esc(p.get('first_bullet',''))}</li>" for p in previews_research
+    )
+    legal_rows = "".join(
+        f"<tr><td>{esc(k)}</td><td>{esc(str(v))}</td></tr>" for k, v in legal.items()
     )
 
     html = f"""<!doctype html>
@@ -100,6 +104,15 @@ code {{ background: #f7f7f7; padding: 1px 4px; border-radius: 4px; }}
 <div class=\"card\">
   <h2>Previews (Research)</h2>
   <ul>{preview_research_list or '<li>None</li>'}</ul>
+</div>
+
+<div class=\"card\">
+  <h2>Legal Summary</h2>
+  <table>
+    <thead><tr><th>Gate</th><th>Status/Counts</th></tr></thead>
+    <tbody>{legal_rows or '<tr><td colspan=2><i>No legal data</i></td></tr>'}</tbody>
+  </table>
+  <p style=\"font-size: 12px; color: #888\">See Legal Guardrails doc and policy.yaml for configuration. [teach §Legal]</p>
 </div>
 
 </body>

--- a/src/scraper/orchestrator.py
+++ b/src/scraper/orchestrator.py
@@ -203,6 +203,7 @@ class ShipLocalOrchestrator:
             "params": params,
             "previews_quiz": previews_quiz,
             "previews_research": previews_research,
+            "legal": ctx.get("legal", {}),
         })
         self.console.print(f"[green]Report:[/green] {report_path}")
 

--- a/src/scraper/orchestrator.py
+++ b/src/scraper/orchestrator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 from rich.console import Console
 from rich.markdown import Markdown
@@ -38,7 +38,8 @@ class ShipLocalOrchestrator:
             mode: str = "copy",
             strict: bool = False,
             limit: int | None = None,
-            , teach: bool = False
+            teach: bool = False,
+            preview: bool = False,
             ) -> Dict[str, Any]:
         ctx: Dict[str, Any] = {"steps": [], "warnings": []}
 
@@ -130,6 +131,39 @@ class ShipLocalOrchestrator:
         rres = rimp.run()
         self.console.print(f"Created={rres.get('created',0)} Skipped={rres.get('skipped',0)} in {rres.get('repo')}")
 
+        # Optional previews
+        previews_quiz: List[Dict[str, Any]] = []
+        previews_research: List[Dict[str, Any]] = []
+        if preview:
+            # Quiz previews: 2 questions per category
+            for fi in files_info:
+                try:
+                    data = json.loads(Path(fi["file"]).read_text())
+                    qs = data.get("questions", [])
+                    q1 = qs[0].get("question") if len(qs) > 0 else ""
+                    q2 = qs[1].get("question") if len(qs) > 1 else ""
+                    previews_quiz.append({"category": Path(fi["file"]).stem.replace("quiz_",""), "q1": q1, "q2": q2})
+                except Exception:
+                    continue
+            # Research previews: first bullet from each new summary
+            for it in rres.get("items", [])[:10]:
+                try:
+                    lines = Path(it["file"]).read_text().splitlines()
+                    first_bullet = ""
+                    in_summary = False
+                    for ln in lines:
+                        if ln.strip() == "summary:":
+                            in_summary = True
+                            continue
+                        if in_summary and ln.strip().startswith("-"):
+                            first_bullet = ln.strip()[1:].strip()
+                            break
+                        if in_summary and ln.strip() == "":
+                            break
+                    previews_research.append({"slug": it.get("slug"), "first_bullet": first_bullet})
+                except Exception:
+                    continue
+
         # 7) HTML report
         self._log_step("HTML report")
         quizzes_for_report = []
@@ -167,6 +201,8 @@ class ShipLocalOrchestrator:
             "research": research_for_report,
             "warnings": ctx.get("warnings", []),
             "params": params,
+            "previews_quiz": previews_quiz,
+            "previews_research": previews_research,
         })
         self.console.print(f"[green]Report:[/green] {report_path}")
 

--- a/tests/test_simhash.py
+++ b/tests/test_simhash.py
@@ -1,0 +1,20 @@
+import tempfile
+from scraper.harvesters.massive import MassiveHarvester
+
+
+def test_simhash_hamming_distance_behaves():
+    with tempfile.TemporaryDirectory() as td:
+        h = MassiveHarvester(output_dir=td)
+        a = "Kubernetes manages containerized workloads and services"
+        b = "Kubernetes orchestrates containers and services"
+        c = "Redis is an in-memory data structure store"
+        ha = h._simhash64(a)
+        hb = h._simhash64(b)
+        hc = h._simhash64(c)
+        ab = h._hamming(ha, hb)
+        ac = h._hamming(ha, hc)
+        # Similar phrases should be closer than dissimilar ones
+        assert ab < ac
+        # And generally below the default threshold for near-duplicates (8)
+        assert ab < 16
+


### PR DESCRIPTION
This PR introduces:\n\n- Ship: --preview mode, previews in HTML report; teach logs tightened\n- Docs: README positioning + legal overview; EPICS (CE+TDD); JOURNEYS (20 user + 20 S2S); SYSTEM_STATUS; LEGAL_GUARDRAILS; POLICY_TEMPLATE; TAURI UI updates\n- CI+Tests: pytest config/extras, workflow, SimHash unit test\n- Orchestrator/report: legal summary placeholder wiring\n\nAlso seeds GitHub labels, epics, and tasks for CE/TDD and legal/compliance.\n\nAfter merge: next steps are (#33–#36) policy loader and first legal gates (PII/quotes, license, robots).